### PR TITLE
[feat] 후기 등록 api 구현

### DIFF
--- a/src/main/java/com/example/spring/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/spring/domain/member/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring.domain.member;
+
+import com.example.spring.domain.member.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/spring/domain/member/MemberService.java
+++ b/src/main/java/com/example/spring/domain/member/MemberService.java
@@ -1,0 +1,21 @@
+package com.example.spring.domain.member;
+
+import com.example.spring.domain.member.domain.Member;
+import com.example.spring.global.apiResponse.code.status.ErrorStatus;
+import com.example.spring.global.apiResponse.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.expression.spel.ast.OpAnd;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final MemberRepository memberRepository;
+
+    public Member findById(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow(() ->
+                new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/example/spring/domain/member/MemberService.java
+++ b/src/main/java/com/example/spring/domain/member/MemberService.java
@@ -4,7 +4,6 @@ import com.example.spring.domain.member.domain.Member;
 import com.example.spring.global.apiResponse.code.status.ErrorStatus;
 import com.example.spring.global.apiResponse.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.expression.spel.ast.OpAnd;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,5 +16,12 @@ public class MemberService {
     public Member findById(Long memberId){
         return memberRepository.findById(memberId).orElseThrow(() ->
                 new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+    @Transactional
+    public Long saveAndGetDummyID(){
+        Member member = Member.builder()
+                .build();
+        memberRepository.save(member);
+        return member.getMemberId();
     }
 }

--- a/src/main/java/com/example/spring/domain/member/MemberService.java
+++ b/src/main/java/com/example/spring/domain/member/MemberService.java
@@ -17,6 +17,8 @@ public class MemberService {
         return memberRepository.findById(memberId).orElseThrow(() ->
                 new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
+
+    // 만약, member 함수의 제약 조건을 추가한다면, 아래 더미 함수에도 해당 내용 반영해 주세요!
     @Transactional
     public Long saveAndGetDummyID(){
         Member member = Member.builder()

--- a/src/main/java/com/example/spring/domain/member/MemberService.java
+++ b/src/main/java/com/example/spring/domain/member/MemberService.java
@@ -18,7 +18,7 @@ public class MemberService {
                 new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
     }
 
-    // 만약, member 함수의 제약 조건을 추가한다면, 아래 더미 함수에도 해당 내용 반영해 주세요!
+    // 만약, member 엔티티에 제약 조건을 추가한다면, 아래 더미 함수에도 해당 내용 반영해 주세요!
     @Transactional
     public Long saveAndGetDummyID(){
         Member member = Member.builder()

--- a/src/main/java/com/example/spring/domain/member/domain/Member.java
+++ b/src/main/java/com/example/spring/domain/member/domain/Member.java
@@ -29,8 +29,8 @@ public class Member extends BaseEntity {
     private String address;
     private String profileUrl;
 
-    private Integer point;
-    private Integer coupon;
+    private int point = 0;
+    private int coupon = 0;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/com/example/spring/domain/member/domain/Member.java
+++ b/src/main/java/com/example/spring/domain/member/domain/Member.java
@@ -24,9 +24,6 @@ public class Member extends BaseEntity {
     private Long memberId;
 
     private String name;
-    private String nickname;
-    private Integer age;
-    private String address;
     private String profileUrl;
 
     private int point = 0;

--- a/src/main/java/com/example/spring/domain/member/domain/Member.java
+++ b/src/main/java/com/example/spring/domain/member/domain/Member.java
@@ -25,12 +25,12 @@ public class Member extends BaseEntity {
 
     private String name;
     private String nickname;
-    private int age;
+    private Integer age;
     private String address;
     private String profileUrl;
 
-    private int point;
-    private int coupon;
+    private Integer point;
+    private Integer coupon;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/com/example/spring/domain/review/ReviewController.java
+++ b/src/main/java/com/example/spring/domain/review/ReviewController.java
@@ -1,0 +1,24 @@
+package com.example.spring.domain.review;
+
+import com.example.spring.domain.review.domain.Review;
+import com.example.spring.domain.review.dto.ReviewRequestDTO;
+import com.example.spring.global.apiResponse.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+    private final ReviewService reviewService;
+
+    @PostMapping("/")
+    public ApiResponse<Boolean> join(@RequestBody @Valid ReviewRequestDTO.ReviewSaveDto request){
+        Review review = reviewService.createReview(request);
+        return ApiResponse.onSuccess(Boolean.TRUE);
+    }
+}

--- a/src/main/java/com/example/spring/domain/review/ReviewRepository.java
+++ b/src/main/java/com/example/spring/domain/review/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.example.spring.domain.review;
+
+import com.example.spring.domain.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review,Long> {
+}

--- a/src/main/java/com/example/spring/domain/review/ReviewService.java
+++ b/src/main/java/com/example/spring/domain/review/ReviewService.java
@@ -1,0 +1,35 @@
+package com.example.spring.domain.review;
+
+import com.example.spring.domain.member.domain.Member;
+import com.example.spring.domain.member.MemberService;
+import com.example.spring.domain.review.domain.Review;
+import com.example.spring.domain.review.dto.ReviewRequestDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReviewService {
+    private final ReviewRepository reviewRepository;
+    private final MemberService memberService;
+    @Transactional
+    public Review createReview(ReviewRequestDTO.ReviewSaveDto request) {
+        Review review = toReviewEntity(request);
+        reviewRepository.save(review);
+        return review;
+    }
+
+    private Review toReviewEntity(ReviewRequestDTO.ReviewSaveDto request) {
+        Member member = memberService.findById(request.getMemberId());
+        Review review = Review.builder()
+                .title(request.getTitle())
+                .body(request.getBody())
+                .member(member)
+                .build();
+        review.updateReviewImages(request.getImageUrlList());
+        review.updateSpots(request.getSpotList());
+        return review;
+    }
+}

--- a/src/main/java/com/example/spring/domain/review/domain/Review.java
+++ b/src/main/java/com/example/spring/domain/review/domain/Review.java
@@ -1,11 +1,13 @@
 package com.example.spring.domain.review.domain;
 import com.example.spring.domain.member.domain.Member;
+import com.example.spring.global.apiResponse.code.status.ErrorStatus;
+import com.example.spring.global.apiResponse.exception.GeneralException;
 import com.example.spring.global.baseEntity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Entity
 @Builder
@@ -24,7 +26,7 @@ public class Review extends BaseEntity {
     private String spot2;
     private String spot3;
 
-    private int heart;
+    private int heart = 0;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "memberId")
@@ -32,4 +34,29 @@ public class Review extends BaseEntity {
 
     @OneToMany (mappedBy = "review", cascade = CascadeType.ALL)
     private List<ReviewImage> reviewImageList = new ArrayList<>();
+
+    public void updateSpots(List<String> spots){
+        Set<String> uniqueSpots = new HashSet<>(spots);
+
+        if(uniqueSpots.isEmpty() || uniqueSpots.size() > 3) {
+            throw new GeneralException(ErrorStatus.REVIEW_SPOT_QUANTITY_ERROR);
+        }
+
+        Iterator<String> spotIterator = uniqueSpots.iterator();
+
+        spot1 = spotIterator.hasNext() ? spotIterator.next() : null;
+        spot2 = spotIterator.hasNext() ? spotIterator.next() : null;
+        spot3 = spotIterator.hasNext() ? spotIterator.next() : null;
+    }
+    public void updateReviewImages(List<String> reviewImages){
+        Set<String> uniqueImages = new HashSet<>(reviewImages);
+
+        if(uniqueImages.isEmpty() || uniqueImages.size() > 5) {
+            throw new GeneralException(ErrorStatus.REVIEW_IMAGE_QUANTITY_ERROR);
+        }
+
+        reviewImageList = uniqueImages.stream()
+                .map(imageUrl -> ReviewImage.builder().imgUrl(imageUrl).build())
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/spring/domain/review/dto/ReviewRequestDTO.java
+++ b/src/main/java/com/example/spring/domain/review/dto/ReviewRequestDTO.java
@@ -1,0 +1,25 @@
+package com.example.spring.domain.review.dto;
+
+import com.example.spring.domain.review.domain.Review;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+public class ReviewRequestDTO {
+    @Getter
+    public static class ReviewSaveDto {
+        @NotNull
+        Long memberId;
+        @NotBlank
+        String title;
+        @NotBlank
+        String body;
+        @NotEmpty
+        List<String> spotList;
+        @NotEmpty
+        List<String> imageUrlList;
+    }
+}

--- a/src/main/java/com/example/spring/global/apiResponse/ApiResponse.java
+++ b/src/main/java/com/example/spring/global/apiResponse/ApiResponse.java
@@ -33,7 +33,7 @@ public class ApiResponse<T> {
 
     // 실패한 경우 응답 생성
     public static <T> ApiResponse<T> onFailure(String code, String message, T data){
-        return new ApiResponse<>(true, code, message, data);
+        return new ApiResponse<>(false, code, message, data);
     }
 
 

--- a/src/main/java/com/example/spring/global/apiResponse/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spring/global/apiResponse/code/status/ErrorStatus.java
@@ -37,7 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리가 없습니다."),
 
     // 리뷰 관련 에러
-    REVIEW_PICTURE_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰에 첨부된 사진이 없거나 너무 많습니다."),
+    REVIEW_IMAGE_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰에 첨부된 사진이 없거나 너무 많습니다."),
     REVIEW_SPOT_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "REVIEW4002", "리뷰 장소가 없거나 너무 많습니다.");
 
 

--- a/src/main/java/com/example/spring/global/apiResponse/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/spring/global/apiResponse/code/status/ErrorStatus.java
@@ -34,7 +34,11 @@ public enum ErrorStatus implements BaseErrorCode {
     // Region Error
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "지역이 없습니다."),
     // Category Error
-    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리가 없습니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001", "카테고리가 없습니다."),
+
+    // 리뷰 관련 에러
+    REVIEW_PICTURE_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "REVIEW4001", "리뷰에 첨부된 사진이 없거나 너무 많습니다."),
+    REVIEW_SPOT_QUANTITY_ERROR(HttpStatus.BAD_REQUEST, "REVIEW4002", "리뷰 장소가 없거나 너무 많습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/test/java/com/example/spring/domain/review/ReviewControllerTest.java
+++ b/src/test/java/com/example/spring/domain/review/ReviewControllerTest.java
@@ -1,0 +1,215 @@
+package com.example.spring.domain.review;
+
+import com.example.spring.domain.member.MemberService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class ReviewControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private MemberService memberService;
+    private Long memberId;
+    // 테스트 전에 실행되는 메소드
+    @BeforeEach
+    public void setup() {
+        // 더미 멤버 데이터 생성
+        memberId = memberService.saveAndGetDummyID();
+    }
+
+    @Test
+    public void testCreateReviewWithValidData() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isOk());
+    }
+    @Test
+    public void testCreateReviewWithEmptyData() throws Exception {
+        String reviewJson = "{}";
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithEmptyMemberId() throws Exception {
+        String reviewJson = String.format(
+                "{\"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\"]}");
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithEmptyTitle() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithEmptyBody() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void testCreateReviewWithNullSpotList() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithEmptySpotList() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void testCreateReviewWithThreeSpots() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"spot1\",\"spot2\",\"spot3\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isOk());
+    }
+    @Test
+    public void testCreateReviewWithFourSpots() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"spot1\",\"spot2\",\"spot3\",\"spot4\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+    @Test
+    public void testCreateReviewWithThreeSpotsWithDuplicateOne() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"spot1\",\"spot2\",\"spot3\",\"spot3\"], " +
+                        "\"imageUrlList\": [\"url1\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isOk());
+    }
+    @Test
+    public void testCreateReviewWithNullImages() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], ", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithEmptyImages() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": []}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithFiveImages() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\",\"url2\",\"url3\",\"url4\",\"url5\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    public void testCreateReviewWithSixImages() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\",\"url2\",\"url3\",\"url4\",\"url5\",\"url6\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void testCreateReviewWithFiveImagesWithOneDuplicateImage() throws Exception {
+        String reviewJson = String.format(
+                "{\"memberId\": %d, \"title\": \"정상 리뷰1\", \"body\": \"글 1\", " +
+                        "\"spotList\": [\"한강\"], " +
+                        "\"imageUrlList\": [\"url1\",\"url2\",\"url3\",\"url4\",\"url5\",\"url5\"]}", memberId);
+
+        mockMvc.perform(post("/reviews/")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(reviewJson))
+                .andExpect(status().isOk());
+    }
+}


### PR DESCRIPTION
1. 비즈니스 로직 실행 중 예외 발생한 경우, 응답의 isSuccess 필드가 true인 버그가 존재 -> 해당 버그 수정
2. 후기 비즈니스 로직 구현을 위해, Member 관련 service 및 repository가 필요 -> 해당 부분을 임시로 구현 
3. 후기 등록 관련 ErrorStatus를 추가
4. 후기 등록 시, image 갯수 제약, 장소 갯수 제약이 필요 -> Review entity에 해당 필드를 업데이트 할 때, 검사
5. 후기 등록 API 구현 및 관련 test case 작성
## 주의
- 임시로 Member dummy 생성 함수를 MemberService에 구현하였습니다. Member  엔티티에 제약 조건을 추가한다면, 해당 더미 함수에도 내용을 반영해 주세요!